### PR TITLE
OTC-712 Create client sending requests to MUSE

### DIFF
--- a/muse_payment_adaptor/api_interface/dataclasses/__init__.py
+++ b/muse_payment_adaptor/api_interface/dataclasses/__init__.py
@@ -1,0 +1,2 @@
+from .bulkyPayment import *
+

--- a/muse_payment_adaptor/api_interface/dataclasses/__init__.py
+++ b/muse_payment_adaptor/api_interface/dataclasses/__init__.py
@@ -1,2 +1,2 @@
-from .bulkyPayment import *
-
+from .bulkyPayment import BulkyPaymentMessageHeader, BulkyPaymentSummary, BulkyPaymentPayListElement, \
+    BulkyPaymentSubmissionRequestMessage, BulkyPaymentSubmissionRequest

--- a/muse_payment_adaptor/api_interface/dataclasses/bulkyPayment.py
+++ b/muse_payment_adaptor/api_interface/dataclasses/bulkyPayment.py
@@ -1,0 +1,42 @@
+from pydantic import BaseModel
+from typing import List
+
+
+class BulkyPaymentMessageHeader(BaseModel):
+    sender: str
+    receiver: str
+    msgId: str
+    messageType: str
+    paymentType: str
+
+
+class BulkyPaymentSummary(BaseModel):
+    institutioncode: str  # "T1120000"
+    totalAmount: str  # "72274.00"
+    referenceNo: str  # "4020"
+    paymentDesc: str  # "REFUND LOANEES WITH AMOUNT"
+    applyDate: str  # "2022-09-11 18:59:49.104"
+    noofTransaction: int  # 3  # Programmatically created based on payList
+    isSTP: bool  # True
+
+
+class BulkyPaymentPayListElement(BaseModel):
+    paymentChannel: str  # Literal['Bank Account', 'Mobile']
+    payeeCode: str  # "S09260061"  # HF / EO ?
+    payeeName: str  # "IBRAHIM N KIMAMBO"  # HF / EO Name?
+    payeeAccountNumber: str  # "9821231996"  # EO Bank account?
+    payeeAccountName: str  # "IBRAHIM N KIMAMBO"
+    payeeBankName: str  # "ACCESSBANK"
+    payeeBankBic: str  # "ACTZTZTZ"
+    amount: str  # "18244.0"  # Shouldn't be numeric?
+
+
+class BulkyPaymentSubmissionRequestMessage(BaseModel):
+    messageHeader: BulkyPaymentMessageHeader
+    paymentSummary: BulkyPaymentSummary
+    payList: List[BulkyPaymentPayListElement]
+
+
+class BulkyPaymentSubmissionRequest(BaseModel):
+    message: BulkyPaymentSubmissionRequestMessage
+    digitalSignature: str

--- a/muse_payment_adaptor/api_interface/dataclasses/bulkyPayment.py
+++ b/muse_payment_adaptor/api_interface/dataclasses/bulkyPayment.py
@@ -11,24 +11,24 @@ class BulkyPaymentMessageHeader(BaseModel):
 
 
 class BulkyPaymentSummary(BaseModel):
-    institutioncode: str  # "T1120000"
-    totalAmount: str  # "72274.00"
-    referenceNo: str  # "4020"
-    paymentDesc: str  # "REFUND LOANEES WITH AMOUNT"
-    applyDate: str  # "2022-09-11 18:59:49.104"
-    noofTransaction: int  # 3  # Programmatically created based on payList
-    isSTP: bool  # True
+    institutioncode: str
+    totalAmount: str
+    referenceNo: str
+    paymentDesc: str
+    applyDate: str
+    noofTransaction: int
+    isSTP: bool
 
 
 class BulkyPaymentPayListElement(BaseModel):
-    paymentChannel: str  # Literal['Bank Account', 'Mobile']
-    payeeCode: str  # "S09260061"  # HF / EO ?
-    payeeName: str  # "IBRAHIM N KIMAMBO"  # HF / EO Name?
-    payeeAccountNumber: str  # "9821231996"  # EO Bank account?
-    payeeAccountName: str  # "IBRAHIM N KIMAMBO"
-    payeeBankName: str  # "ACCESSBANK"
-    payeeBankBic: str  # "ACTZTZTZ"
-    amount: str  # "18244.0"  # Shouldn't be numeric?
+    paymentChannel: str
+    payeeCode: str
+    payeeName: str
+    payeeAccountNumber: str
+    payeeAccountName: str
+    payeeBankName: str
+    payeeBankBic: str
+    amount: str
 
 
 class BulkyPaymentSubmissionRequestMessage(BaseModel):

--- a/muse_payment_adaptor/api_interface/muse_api_client.py
+++ b/muse_payment_adaptor/api_interface/muse_api_client.py
@@ -1,0 +1,158 @@
+import json
+import logging
+from abc import ABC
+from typing import List, Tuple, Union
+
+from pydantic import BaseModel
+
+from core.datetimes.ad_datetime import datetime
+from invoice.models import Bill, BillItem
+from muse_payment_adaptor.api_interface.dataclasses import BulkyPaymentSubmissionRequest, \
+    BulkyPaymentSubmissionRequestMessage, BulkyPaymentMessageHeader, BulkyPaymentSummary, BulkyPaymentPayListElement
+from muse_payment_adaptor.api_interface.muse_http_client import MuseAdaptorHttpClient
+from muse_payment_adaptor.api_interface.signature import create_signature_b64_string
+from muse_payment_adaptor.apps import MusePaymentAdaptorConfig
+from muse_payment_adaptor.models import PaymentRequest, PaymentRequestDetails
+
+logger = logging.getLogger(__name__)
+_default_http_client = MuseAdaptorHttpClient(MusePaymentAdaptorConfig.muse_base_uri)
+
+
+# region ABC
+
+class MuseApiClient(ABC):
+    def __init__(self, api_http_client: MuseAdaptorHttpClient = _default_http_client):
+        self.api_http_client = api_http_client
+
+    @property
+    def _api_endpoint(self) -> str:
+        """
+        This property specifies the exact endpoint to be used by the client. The endpoint will be joined with root path
+        from the MuseAdaptorHttpClient.
+        """
+        raise NotImplementedError("`api_endpoint` not implemented")
+
+    def _submit(self, model: BaseModel) -> str:
+        response = self.api_http_client.send_post_request(self._api_endpoint, model.json())
+        if response.ok:
+            return response.content.decode('utf-8')
+        else:
+            logger.error(f"Muse request failed, HTTP code {response.status_code}")
+
+    def _build_message_signature(self, message: BaseModel) -> str:
+        # To JSON, To UTF-8 bytes
+        encoded_msg = json.dumps({'message': message.dict()}).encode('utf-8')
+        # Create signature, To b64 bytes, To b64 string (ascii)
+        signature_str = create_signature_b64_string(encoded_msg)
+        return signature_str
+
+
+# endregion
+# region BP
+
+class BulkPaymentSubmissionClient(MuseApiClient):
+    _api_endpoint = MusePaymentAdaptorConfig.muse_post_bp_endpoint
+
+    def submit_bulky_payment(self, bill: Bill, payment_desc: str = '') \
+            -> Union[Tuple[PaymentRequest, str], Tuple[None, None]]:
+        """
+        Submit Bill as bulky payment to MUSE Api. This method will send the submission and save the request in the
+        database.
+
+        :param bill: Bill to be submitted
+        :param payment_desc: Payment description to be included with the submission
+        :return: tuple of PaymentRequest database model and response content, if the request is successful
+        """
+        try:
+            request = self._build_request(bill, payment_desc)
+            request_model = self._store_request(request)
+            # TODO update model after submit?
+            return request_model, self._submit(request)
+        except BaseException as e:
+            logger.error("Error while sending MUSE request", exc_info=e)
+            return None, None
+
+    def _build_request_message(self, bill: Bill, description: str) -> BulkyPaymentSubmissionRequestMessage:
+        message_header = self._build_request_message_header(bill)
+        message_content = self._build_request_message_summary(bill, description)
+        pay_list = self._build_request_pay_list(bill)
+        return BulkyPaymentSubmissionRequestMessage(
+            messageHeader=message_header,
+            paymentSummary=message_content,
+            payList=pay_list,
+        )
+
+    def _build_request(self, bill: Bill, description: str) -> BulkyPaymentSubmissionRequest:
+        message = self._build_request_message(bill, description)
+        signature = self._build_message_signature(message)
+        return BulkyPaymentSubmissionRequest(
+            message=message,
+            digitalSignature=signature
+        )
+
+    def _build_request_message_header(self, bill: Bill) -> BulkyPaymentMessageHeader:
+        return BulkyPaymentMessageHeader(
+            sender=MusePaymentAdaptorConfig.muse_api_sender,
+            receiver=MusePaymentAdaptorConfig.muse_api_receiver,
+            msgId=str(bill.uuid),
+            messageType=MusePaymentAdaptorConfig.muse_bp_header_message_type,
+            paymentType=MusePaymentAdaptorConfig.muse_bp_header_payment_type,
+        )
+
+    def _build_request_message_summary(self, bill: Bill, description: str) -> BulkyPaymentSummary:
+        return BulkyPaymentSummary(
+            institutioncode=MusePaymentAdaptorConfig.muse_bp_message_institution_code,
+            totalAmount=bill.amount_net,
+            referenceNo=str(bill.uuid),
+            paymentDesc=description,
+            applyDate=str(datetime.now()),
+            noofTransaction=bill.line_items_bill.count(),
+            isSTP=False,
+        )
+
+    def _build_request_pay_list(self, bill: Bill) -> List[BulkyPaymentPayListElement]:
+        pay_list = []
+        for bill_item in bill.line_items_bill.all():
+            pay_list.append(self._build_request_pay_list_element(bill_item))
+        return pay_list
+
+    def _build_request_pay_list_element(self, line_item: BillItem) -> BulkyPaymentPayListElement:
+        return BulkyPaymentPayListElement(
+            paymentChannel='',
+            payeeCode='',
+            payeeName='',
+            payeeAccountNumber='',
+            payeeAccountName='',
+            payeeBankName='',
+            payeeBankBic='',
+            amount=line_item.amount_net,
+        )  # TODO API call to request this info ?
+
+    def _store_request(self, request: BulkyPaymentSubmissionRequest) -> PaymentRequest:
+        request_model = PaymentRequest.objects.create(**{
+            'message_id': request.message.messageHeader.msgId,
+            'payment_type': request.message.messageHeader.paymentType,
+            'reference_no': request.message.paymentSummary.referenceNo,
+            'payment_description': request.message.paymentSummary.paymentDesc,
+            'total_amount': request.message.paymentSummary.totalAmount,
+            'no_of_tnx': len(request.message.payList),
+            'status': None,
+            'record_date': datetime.now(),
+        })
+
+        for pay_list_item in request.message.payList:
+            PaymentRequestDetails.objects.create(**{
+                'payment_request': request_model,
+                'payee_code': pay_list_item.payeeCode,
+                'name': pay_list_item.payeeName,
+                'acc_no': pay_list_item.payeeAccountNumber,
+                'acc_name': pay_list_item.payeeAccountName,
+                'bank': pay_list_item.payeeBankBic,
+                'bank_bic': pay_list_item.payeeBankBic,
+                'amount': pay_list_item.amount,
+                'payment_channel': pay_list_item.paymentChannel,
+            })
+
+        return request_model
+
+# endregion

--- a/muse_payment_adaptor/api_interface/muse_http_client.py
+++ b/muse_payment_adaptor/api_interface/muse_http_client.py
@@ -1,0 +1,44 @@
+import logging
+from typing import Any
+from urllib.parse import urljoin, urlencode
+
+import requests
+from requests import Response
+
+from muse_payment_adaptor.apps import MusePaymentAdaptorConfig
+
+logger = logging.getLogger(__name__)
+
+
+class MuseAdaptorHttpClient:
+    """
+    Http client to be used for muse http requests
+    """
+
+    def __init__(self, url: str):
+        """
+        :param url: Root url for all request from this client
+        """
+        self.url = url
+
+    def send_post_request(self, path: str, body: Any) -> Response:
+        """
+        Send POST request to the endpoint with a given data.
+
+        :param path: Endpoint to send the data to. Will be joined with url provided in constructor
+        :param body: Body arguments for POST request
+        """
+        url = self._build_url(path)
+        try:
+            return requests.post(url=url, data=body, headers=self._build_headers())
+        except requests.exceptions.RequestException as e:
+            logger.error("POST request to Muse API failed", exc_info=e)
+
+    def _build_headers(self) -> dict:
+        return MusePaymentAdaptorConfig.muse_request_headers
+
+    def _build_url(self, uri, query_params=None) -> str:
+        url = urljoin(self.url, uri)
+        if query_params:
+            url.query = urlencode(query_params)
+        return url.geturl()

--- a/muse_payment_adaptor/api_interface/muse_http_client.py
+++ b/muse_payment_adaptor/api_interface/muse_http_client.py
@@ -15,20 +15,20 @@ class MuseAdaptorHttpClient:
     Http client to be used for muse http requests
     """
 
-    def __init__(self, url: str):
+    def __init__(self, root_url: str):
         """
-        :param url: Root url for all request from this client
+        :param root_url: Root url for all request from this client
         """
-        self.url = url
+        self.root_url = root_url
 
-    def send_post_request(self, path: str, body: Any) -> Response:
+    def send_post_request(self, endpoint_url: str, body: Any) -> Response:
         """
         Send POST request to the endpoint with a given data.
 
-        :param path: Endpoint to send the data to. Will be joined with url provided in constructor
+        :param endpoint_url: Endpoint to send the data to. Will be joined with url provided in constructor
         :param body: Body arguments for POST request
         """
-        url = self._build_url(path)
+        url = self._build_url(endpoint_url)
         try:
             return requests.post(url=url, data=body, headers=self._build_headers())
         except requests.exceptions.RequestException as e:
@@ -37,8 +37,12 @@ class MuseAdaptorHttpClient:
     def _build_headers(self) -> dict:
         return MusePaymentAdaptorConfig.muse_request_headers
 
-    def _build_url(self, uri, query_params=None) -> str:
-        url = urljoin(self.url, uri)
+    def _build_url(self, endpoint_url, query_params=None) -> str:
+        url = urljoin(self.root_url, endpoint_url)
         if query_params:
             url.query = urlencode(query_params)
         return url.geturl()
+
+    @staticmethod
+    def get_default():
+        return MuseAdaptorHttpClient(MusePaymentAdaptorConfig.muse_base_uri)

--- a/muse_payment_adaptor/api_interface/signature.py
+++ b/muse_payment_adaptor/api_interface/signature.py
@@ -1,3 +1,4 @@
+import base64
 import logging
 
 from cryptography.exceptions import InvalidSignature
@@ -12,13 +13,36 @@ __algorithm = hashes.SHA1()
 logger = logging.getLogger(__name__)
 
 
-def create_signature(message: bytes) -> bytes:
+def create_signature_bytes(message: bytes) -> bytes:
+    """
+    For a given message, create a signature returned as byte array. To use the signature in text payload use
+    create_signature_b64_string
+    """
     certificate = MusePaymentAdaptorConfig.certificate
     signature = certificate.key.sign(message, padding=__padding, algorithm=__algorithm)
     return signature
 
 
-def verify_signature(message: bytes, signature: bytes) -> bool:
+def create_signature_b64_bytes(message: bytes) -> bytes:
+    """
+    For a given message, create a signature encoded as base64, returned as byte array. Intermediate format between
+    byte array and b64 string. To use the signature in text payload use create_signature_b64_string
+    """
+    return base64.encodebytes(create_signature_bytes(message))
+
+
+def create_signature_b64_string(message: bytes) -> str:
+    """
+    For a given message, create a signature encoded as base64, returned as string. To be used in string payloads.
+    """
+    return create_signature_b64_bytes(message).decode('ascii')
+
+
+def verify_signature_bytes(message: bytes, signature: bytes) -> bool:
+    """
+    For a given message, check if a signature (provided as byte array) is valid. Should be true for a signature created
+    with create_signature_bytes. To validate the signature from text payload (b64) use verify_signature_b64_string.
+    """
     certificate = MusePaymentAdaptorConfig.certificate
     public_key = certificate.key.public_key()
     try:
@@ -32,3 +56,20 @@ def verify_signature(message: bytes, signature: bytes) -> bool:
     except InvalidSignature:
         logger.debug("Signature validation failed")
         return False
+
+
+def verify_signature_b64_bytes(message: bytes, signature: bytes) -> bool:
+    """
+    For a given message, check if a signature (encoded in base64, provided as byte array) is valid. Should be true for
+    a signature created with create_signature_b64_bytes. To validate the signature from text payload (b64) use
+    verify_signature_b64_string.
+    """
+    return verify_signature_bytes(message, base64.decodebytes(signature))
+
+
+def verify_signature_b64_string(message: bytes, signature: str) -> bool:
+    """
+    For a given message, check if a signature (encoded in base64, provided as string) is valid. Should be true for
+    a signature created with create_signature_b64_string. To be used to validate the signature from text payload.
+    """
+    return verify_signature_b64_bytes(message, str.encode(signature, 'ascii'))

--- a/muse_payment_adaptor/apps.py
+++ b/muse_payment_adaptor/apps.py
@@ -7,6 +7,19 @@ from django.apps import AppConfig
 from django.utils.functional import classproperty
 
 DEFAULT_CONFIG = {
+    'muse_base_uri': 'http://<FBIP>:<port>',  # TODO: Enter MUSE API root
+    'muse_post_bp_endpoint': 'api/MUSE/postbulky',
+    'muse_request_headers': {
+        'content-type': 'application/json',
+        'MUSE-Com': 'default.sp.in',
+        'Institution Code': 'IMIS',
+        'service-code': 'SRVC044'  # TODO: Remove, for test instance only
+    },
+    'muse_api_sender': 'IMIS',
+    'muse_api_receiver': 'MUSE',
+    'muse_bp_header_message_type': 'Bulk payment posting',
+    'muse_bp_header_payment_type': 'Bulk payment',
+    'muse_bp_message_institution_code': '<institution_code>',  # TODO: To be defined
     'certificates_path': 'certificates',  # Relative path from `openimis-be` where certificates are stored
     'certificate_name': 'certificate.pfx',  # Filename, relative path from certificates_path directory
     'certificate_password': str.encode('<certificate_password>'),
@@ -22,6 +35,17 @@ logger = logging.getLogger(__name__)
 
 class MusePaymentAdaptorConfig(AppConfig):
     name = 'muse_payment_adaptor'
+
+    muse_base_uri = None
+    muse_post_bp_endpoint = None
+    muse_request_headers = None
+
+    muse_api_sender = None
+    muse_api_receiver = None
+
+    muse_bp_header_message_type = None
+    muse_bp_header_payment_type = None
+    muse_bp_message_institution_code = None
 
     certificates_path = None
     certificate_name = None

--- a/muse_payment_adaptor/models.py
+++ b/muse_payment_adaptor/models.py
@@ -1,6 +1,5 @@
 from core.models import HistoryBusinessModel
 from location.models import HealthFacility
-from pyexpat import model
 import uuid
 from django.db import models
 

--- a/muse_payment_adaptor/tests/__init__.py
+++ b/muse_payment_adaptor/tests/__init__.py
@@ -1,2 +1,3 @@
-from muse_payment_adaptor.tests.hf_bank_info_service import *
-from muse_payment_adaptor.tests.signature import *
+from .hf_bank_info_service import *
+from .signature import *
+from .bulky_payment_api_client import *

--- a/muse_payment_adaptor/tests/bulky_payment_api_client.py
+++ b/muse_payment_adaptor/tests/bulky_payment_api_client.py
@@ -1,0 +1,68 @@
+import json
+import unittest
+from unittest.mock import patch
+
+from core.models import User
+from muse_payment_adaptor.api_interface.muse_api_client import BulkPaymentSubmissionClient, MuseApiClient
+from openIMIS.openimisapps import openimis_apps
+from django.test import TestCase
+
+from muse_payment_adaptor.api_interface.signature import verify_signature_b64_string
+from muse_payment_adaptor.apps import MusePaymentAdaptorConfig
+from muse_payment_adaptor.tests.helpers.signature_data import test_certificate
+
+imis_modules = openimis_apps()
+
+
+class BulkyPaymentApiClientTests(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(BulkyPaymentApiClientTests, cls).setUpClass()
+        cls.api_client = BulkPaymentSubmissionClient()
+        if not User.objects.filter(username='admin_muse').exists():
+            User.objects.create_superuser(username='admin_muse', password='S\/pe®Pąßw0rd™')
+        cls.user = User.objects.filter(username='admin_muse').first()
+
+    def _get_bill(self):
+        required_modules = ['invoice', 'calcrule_unconditional_cash_payment', 'contribution_plan']
+        if not all([module in imis_modules for module in required_modules]):
+            raise unittest.SkipTest('Required modules not installed')
+
+        from invoice.models import Bill
+        from calcrule_unconditional_cash_payment.calculation_rule import UnconditionalCashPaymentCalculationRule
+        from policy.models import Policy
+        from contribution_plan.models import PaymentPlan
+        policy = Policy.objects.filter(validity_to=None).first()
+        payment_plan = PaymentPlan(**{
+            'code': 'TestCode',
+            'name': 'TestName',
+            'periodicity': 12,
+            'calculation': '16bca786-1c12-4e8e-9cbf-e33c2a6d9f4f',
+            'benefit_plan': policy.product,
+            'json_ext': {'calculation_rule': {'lumpsum_to_be_paid': '50', 'invoice_label': 'invoice label'}},
+        })
+        payment_plan.save(username=self.user.username)
+        UnconditionalCashPaymentCalculationRule.active_for_object(instance=policy, context='PolicyCreated',
+                                                                  type='account_payable', sub_type='cash_payment')
+        UnconditionalCashPaymentCalculationRule.calculate(instance=policy, context='PolicyCreated', user=self.user)
+        return Bill.objects.first()
+
+    @patch.object(MusePaymentAdaptorConfig, 'certificate', new=test_certificate)
+    def test_generate_message_from_bill(self):
+        bill = self._get_bill()
+        payload = self.api_client._build_request(bill, 'test_description')
+        self.assertTrue(payload)
+
+    @patch.object(MuseApiClient, '_submit', new=lambda self, x: None)
+    @patch.object(MusePaymentAdaptorConfig, 'certificate', new=test_certificate)
+    def test_generate_payment_request_model(self):
+        bill = self._get_bill()
+        payment_request, _ = self.api_client.submit_bulky_payment(bill, 'test_description')
+        self.assertTrue(payment_request)
+
+    @patch.object(MusePaymentAdaptorConfig, 'certificate', new=test_certificate)
+    def test_generate_valid_message_signature(self):
+        bill = self._get_bill()
+        payload = self.api_client._build_request(bill, 'test_description').dict()
+        signature_b64 = payload.pop('digitalSignature', None)
+        self.assertTrue(verify_signature_b64_string(str.encode(json.dumps(payload)), signature_b64))

--- a/muse_payment_adaptor/tests/bulky_payment_api_client.py
+++ b/muse_payment_adaptor/tests/bulky_payment_api_client.py
@@ -9,6 +9,7 @@ from django.test import TestCase
 
 from muse_payment_adaptor.api_interface.signature import verify_signature_b64_string
 from muse_payment_adaptor.apps import MusePaymentAdaptorConfig
+from muse_payment_adaptor.models import PaymentRequest
 from muse_payment_adaptor.tests.helpers.signature_data import test_certificate
 
 imis_modules = openimis_apps()
@@ -57,7 +58,8 @@ class BulkyPaymentApiClientTests(TestCase):
     @patch.object(MusePaymentAdaptorConfig, 'certificate', new=test_certificate)
     def test_generate_payment_request_model(self):
         bill = self._get_bill()
-        payment_request, _ = self.api_client.submit_bulky_payment(bill, 'test_description')
+        self.api_client.submit_bulky_payment(bill, 'test_description')
+        payment_request = PaymentRequest.objects.filter(message_id=str(bill.uuid)).first()
         self.assertTrue(payment_request)
 
     @patch.object(MusePaymentAdaptorConfig, 'certificate', new=test_certificate)

--- a/muse_payment_adaptor/tests/helpers/signature_data.py
+++ b/muse_payment_adaptor/tests/helpers/signature_data.py
@@ -1,4 +1,4 @@
-import struct
+
 from base64 import b64decode
 
 from cryptography.hazmat.primitives.serialization.pkcs12 import load_pkcs12

--- a/muse_payment_adaptor/tests/signature.py
+++ b/muse_payment_adaptor/tests/signature.py
@@ -1,9 +1,9 @@
 from unittest.mock import patch
 
 from django.test import TestCase
-from base64 import b64encode
 
-from muse_payment_adaptor.api_interface.signature import create_signature, verify_signature
+from muse_payment_adaptor.api_interface.signature import create_signature_bytes, verify_signature_bytes, \
+    create_signature_b64_bytes, create_signature_b64_string, verify_signature_b64_bytes, verify_signature_b64_string
 from muse_payment_adaptor.tests.helpers.signature_data import test_message, test_certificate, test_signature, \
     test_wrong_signature
 from muse_payment_adaptor.apps import MusePaymentAdaptorConfig
@@ -17,15 +17,24 @@ class SignatureTests(TestCase):
 
     @patch.object(MusePaymentAdaptorConfig, 'certificate', new=test_certificate)
     def test_sign_message(self):
-        signature = create_signature(test_message)
+        signature = create_signature_bytes(test_message)
         self.assertTrue(signature)
-        self.assertTrue(verify_signature(test_message, signature))
+        self.assertTrue(verify_signature_bytes(test_message, signature))
 
     @patch.object(MusePaymentAdaptorConfig, 'certificate', new=test_certificate)
     def test_verify_signature(self):
-        self.assertTrue(verify_signature(test_message, test_signature))
+        self.assertTrue(verify_signature_bytes(test_message, test_signature))
 
     @patch.object(MusePaymentAdaptorConfig, 'certificate', new=test_certificate)
     def test_verify_signature_fail(self):
-        self.assertFalse(verify_signature(test_message, test_wrong_signature))
+        self.assertFalse(verify_signature_bytes(test_message, test_wrong_signature))
 
+    @patch.object(MusePaymentAdaptorConfig, 'certificate', new=test_certificate)
+    def test_verify_created_signature(self):
+        signature_bytes = create_signature_bytes(test_message)
+        signature_b64_bytes = create_signature_b64_bytes(test_message)
+        signature_b64_str = create_signature_b64_string(test_message)
+
+        self.assertTrue(verify_signature_bytes(test_message, signature_bytes))
+        self.assertTrue(verify_signature_b64_bytes(test_message, signature_b64_bytes))
+        self.assertTrue(verify_signature_b64_string(test_message, signature_b64_str))

--- a/muse_payment_adaptor/urls.py
+++ b/muse_payment_adaptor/urls.py
@@ -1,6 +1,5 @@
 from . import views
-from django.urls import path, include
-from rest_framework.routers import DefaultRouter
+from django.urls import path
 
 urlpatterns = [
     path('bulkpayment', views.make_bulk_payment, name='bulkpayment'),

--- a/muse_payment_adaptor/views.py
+++ b/muse_payment_adaptor/views.py
@@ -1,5 +1,4 @@
-from muse_payment_adaptor import serializer
-from muse_payment_adaptor.models import PaymentRequestDetails, PaymentResponseDetails
+from muse_payment_adaptor.models import PaymentResponseDetails
 from muse_payment_adaptor.serializer import BulkPaymentResponseSerializer, PaymentRequestSerializer, PaymentSettlementSerializer
 from rest_framework.decorators import api_view
 from rest_framework.response import Response

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         'django-db-signals',
         'djangorestframework',
         'openimis-be-core'
+        'pydantic'
     ],
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
[https://openimis.atlassian.net/browse/OTC-712](https://openimis.atlassian.net/browse/OTC-712)

Changes:
- Added dataclasses for `bulky payment` request payload
- Added `MuseAdaptorHttpClient`, allowing to configure http request to MUSE Api
- Added `MuseApiClient` and `BulkPaymentSubmissionClient` used to submit payloads to MUSE Api
- Added utility methods to signature handling
- Added MUSE Api related config
- Added signature validation to MUSE Api callback endpoints
- Added tests for MUSE Api client
- Added `pydantic` as module dependency